### PR TITLE
Add reusable shared resource factory functions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ indent_size = 2
 
 [*.yml]
 indent_size = 2
+
+[*.json]
+indent_size = 2

--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -10,7 +10,7 @@ import {
 import './FakeSharedEmitter';
 import {FakeSharedEmitter} from "./FakeSharedEmitter";
 import {useEffect, useState} from "react";
-import {createSharedState} from "../src/hooks/use-shared-state";
+import {createSharedState} from "react-shared-states";
 
 FakeSharedEmitter.intervalDuration = 3000;
 window.sharedSubscriptionsApi = sharedSubscriptionsApi;

--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -10,6 +10,7 @@ import {
 import './FakeSharedEmitter';
 import {FakeSharedEmitter} from "./FakeSharedEmitter";
 import {useEffect, useState} from "react";
+import {createSharedState} from "../src/hooks/use-shared-state";
 
 FakeSharedEmitter.intervalDuration = 3000;
 window.sharedSubscriptionsApi = sharedSubscriptionsApi;
@@ -18,8 +19,12 @@ window.sharedStatesApi = sharedStatesApi;
 
 sharedStatesApi.set("x", 55);
 
+const counterGlobal = createSharedState(0);
+
 const Comp1 = () => {
-    const [x, setX] = useSharedState('x', 0);
+    //const [x, setX] = useSharedState('x', 0);
+    //const [x, setX] = useSharedState(counterGlobal);
+    const [x, setX] = useSharedState("counterGlobal", "");
     const handle = (by = 1) => {
         setX(x+by)
     }
@@ -77,7 +82,8 @@ const Comp2 = () => {
 const App = () => {
 
     const [hide, setHide] = useState(false);
-    const [x, setX] = useSharedState('x', 0);
+    const [x, setX] = useSharedState(counterGlobal);
+    //const [x, setX] = useSharedState('x', 0);
     //const [x, setX] = useState(0);
     const handle = () => {
         setX(x+1)

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
   "module": "dist/main.esm.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "tsc": "tsc",
     "bump": "node scripts/bumper.js",
-    "build": "vite build",
+    "build": "tsc && vite build",
     "test": "vitest",
     "preview": "vite preview",
     "dev:demo": "vite --config demo/vite.config.demo.ts",

--- a/src/SharedData.ts
+++ b/src/SharedData.ts
@@ -1,4 +1,4 @@
-import type {AFunction, DataMapValue, Prefix} from "./types";
+import type {AFunction, DataMapValue, Prefix, SharedCreated} from "./types";
 import {useEffect} from "react";
 import {ensureNonEmptyString, log} from "./lib/utils";
 
@@ -150,13 +150,33 @@ export class SharedApi<T>{
     }
 
     /**
+     * resolve a shared created object to a value
+     * @param sharedCreated
+     */
+    resolve(sharedCreated: SharedCreated) {
+        const {key, prefix} = sharedCreated;
+        return this.get(key, prefix);
+    }
+
+    clear(key: string, scopeName: Prefix): void;
+    clear(sharedCreated: SharedCreated): void;
+    /**
      * clear a value from the shared data
      * @param key
      * @param scopeName
      */
-    clear(key: string, scopeName: Prefix) {
-        const prefix: Prefix = scopeName || "_global";
-        this.sharedData.clear(key, prefix);
+    clear(key: string|SharedCreated, scopeName?: Prefix) {
+        let keyStr!: string;
+        let prefixStr!: string;
+        if (typeof key === "string") {
+            keyStr = key;
+            prefixStr = scopeName || "_global";
+        }
+        else{
+            keyStr = key.key;
+            prefixStr = key.prefix;
+        }
+        this.sharedData.clear(keyStr, prefixStr);
     }
 
     /**

--- a/src/context/SharedStatesContext.tsx
+++ b/src/context/SharedStatesContext.tsx
@@ -1,20 +1,21 @@
 import {createContext, type PropsWithChildren, useContext, useMemo} from 'react';
-import type {NonEmptyString} from "../types";
+import type {Prefix} from "../types";
+import {random} from "../lib/utils";
 
 export interface SharedStatesType {
     scopeName: string
 }
 
-const SharedStatesContext = createContext<SharedStatesType | undefined>(undefined);
+export const SharedStatesContext = createContext<SharedStatesType | undefined>(undefined);
 
-interface SharedStatesProviderProps<T extends string = string> extends PropsWithChildren {
-    scopeName?: '__global' extends NonEmptyString<T> ? never : NonEmptyString<T>;
+interface SharedStatesProviderProps extends PropsWithChildren {
+    scopeName?: Prefix;
 }
 
-export const SharedStatesProvider = <T extends string = string>({ children, scopeName }: SharedStatesProviderProps<T>) => {
+export const SharedStatesProvider = ({ children, scopeName }: SharedStatesProviderProps) => {
     if (scopeName && scopeName.includes("//")) throw new Error("scopeName cannot contain '//'");
 
-    if (!scopeName) scopeName = useMemo(() => Math.random().toString(36).substring(2, 15) as NonNullable<SharedStatesProviderProps<T>['scopeName']>, []);
+    if (!scopeName) scopeName = useMemo(() => random() as NonNullable<SharedStatesProviderProps['scopeName']>, []);
 
     return (
         <SharedStatesContext.Provider value={{scopeName}}>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,12 +1,21 @@
 export {
     useSharedState,
-    sharedStatesApi
+    sharedStatesApi,
+    createSharedState,
+    SharedStatesApi
 } from "./use-shared-state";
+export type { SharedStateCreated } from "./use-shared-state";
 export {
     useSharedFunction,
-    sharedFunctionsApi
+    sharedFunctionsApi,
+    createSharedFunction,
+    SharedFunctionsApi
 } from "./use-shared-function";
+export type { SharedFunctionStateReturn } from "./use-shared-function";
 export {
     useSharedSubscription,
-    sharedSubscriptionsApi
+    sharedSubscriptionsApi,
+    createSharedSubscription,
+    SharedSubscriptionsApi
 } from "./use-shared-subscription";
+export type { SharedSubscriptionStateReturn } from "./use-shared-subscription";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,3 @@
-import type {NonEmptyString} from "../types";
 import {isDevMode} from "../config";
 
 export const log = (...args: any[]) => {
@@ -10,7 +9,11 @@ export const log = (...args: any[]) => {
     )
 }
 
-export const ensureNonEmptyString = <T extends string>(value: T): NonEmptyString<T> => {
+export const ensureNonEmptyString = <X extends string>(value: X): X => {
     if (!value) throw new Error("Value is empty");
-    return value as NonEmptyString<T>
+    return value
 };
+
+export const random = () => {
+    return Math.random().toString(36).substring(2, 15);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,4 +8,7 @@ export interface DataMapValue {
     listeners: AFunction[]
 }
 
-export type NonEmptyString<T extends string> = '' extends T ? never : T;
+export interface SharedCreated {
+    key: string,
+    prefix: string,
+}


### PR DESCRIPTION
## 🚀 Purpose

This PR introduces reusable shared resource factory functions and enhances the development workflow by improving documentation, aligning the demo app with the library, and adding strict TypeScript checks to the build process.


## 🧑‍💻 Changes

- Added `createSharedState`, `createSharedFunction`, and `createSharedSubscription` factory functions.
- Updated demo app to use `createSharedState` from the external library for consistency.
- Expanded README with comprehensive examples and API documentation for shared resources.
- Enhanced build process by including TypeScript compilation in the `build` script.
- Introduced `.editorconfig` rules for consistent formatting of JSON and YAML files.


## 🛠️ Fixes or Features

- [ ] **Fix**: If the PR fixes a bug, describe which bug it fixes.
- [x] **Feature**: Introduced reusable shared resource factories and streamlined integration.


## 🔬 Testing

- Manual testing steps:
    - Step 1: Verify `createSharedState`, `createSharedFunction`, and `createSharedSubscription` functionality through the demo app and examples.
    - Step 2: Run the updated build process to ensure proper TypeScript compilation and code output alignment.


## 📚 Documentation

- [x] Documentation has been updated as needed (README, etc.).
- [x] The change has been explained in relevant docs.