### PR TITLE
Update auto-bumper comment to clarify version change

### DIFF
--- a/.github/workflows/auto-bumper.yml
+++ b/.github/workflows/auto-bumper.yml
@@ -64,7 +64,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `Okay BOSS, ⏳ Bumping version to ${pkg.version}...`
+              body: `Okay BOSS, ⏳ Bumping version from ${pkg.version}...`
             })
 
 


### PR DESCRIPTION
Modified the auto-bumper workflow comment to include "from" in the version bump message for improved clarity. This helps better communicate the version transition in pull request comments.